### PR TITLE
fix: connection recover after timeout

### DIFF
--- a/src/rctmon/daemon.py
+++ b/src/rctmon/daemon.py
@@ -159,6 +159,8 @@ class Daemon:
         else:
             socklog.debug('Connection established')
             self._connected = True
+            # reset timer for connection 
+            self._ts.last_data_received = datetime.utcnow() 
 
     def _socket_disconnect(self) -> None:
 


### PR DESCRIPTION
Had issues to reconnect to powerswitch after nightly shutdown. 

rctmon ran into an endless:
```
rctmon.daemon.socket - WARNING - No data received for 180 seconds, disconnecting
rctmon.daemon.socket - INFO - Socket disconnected
rctmon.daemon - INFO - Time to attempt reconnection
```
once the powerswitch shutdown, because of solar power loss at night. 
But in the morning when the powerswitch was back online rctmon didn't recover and stay in that loop.

Small timer reset when connecting fixes this issue. 

Another option would be to change the logic here https://github.com/svalouch/rctmon/blob/main/src/rctmon/daemon.py#L241-L269 and run code in the last else part right after re-connection, which triggers a real read before resetting the counter.  
If you prefere that approach let me know. I will update the PR accordingly.
