### PR TITLE
networking fixes

### DIFF
--- a/src/rctmon/daemon.py
+++ b/src/rctmon/daemon.py
@@ -187,6 +187,9 @@ class Daemon:
         except TimeoutError:
             socklog.warning('Socket receive: Connection timed out')
             self._socket_disconnect()
+        except ConnectionError:
+            socklog.warning('Socket receive: Connection error')
+            self._socket_disconnect()
         else:
             recv_len = len(recv_data)
             socklog.debug('Got %d from socket', recv_len)

--- a/src/rctmon/daemon.py
+++ b/src/rctmon/daemon.py
@@ -159,6 +159,7 @@ class Daemon:
         else:
             socklog.debug('Connection established')
             self._connected = True
+            self._ts.last_data_received = datetime.utcnow()
 
     def _socket_disconnect(self) -> None:
 


### PR DESCRIPTION
i fixed two network-handling related bugs i had problems with:

**reconnect bug:** connection closed due to for example when i unplugged the LAN cable. It then tried to reconnect after 180 seconds but failed because the `last_data_received` timer closed it instantly. I fixed it by resetting the `last_data_received` timer every time the connection is established.

**remaining socket exceptions:** some were unimplemented, I implemented the base class of the connection errors so it catches them all.