### PR TITLE
Switch powerswitch data to own metrics

### DIFF
--- a/src/rctmon/device_manager.py
+++ b/src/rctmon/device_manager.py
@@ -448,6 +448,18 @@ class DeviceManager:
             # g_sync.u_l_rms[2]
             elif oid == 0x2545E22D:
                 self.readings.grid.voltage_l3 = ensure_type(value, float)
+            # g_sync.u_ptp_rms[0]
+            elif oid == 0x63476DBE:
+                self.readings.grid.phase_to_phase_voltage_1 = ensure_type(value, float)
+            # g_sync.u_ptp_rms[1]
+            elif oid == 0x485AD749:
+                self.readings.grid.phase_to_phase_voltage_2 = ensure_type(value, float)
+            # g_sync.u_ptp_rms[2]
+            elif oid == 0xF25C339B:
+                self.readings.grid.phase_to_phase_voltage_3 = ensure_type(value, float)
+            # grid_pll[0].f
+            elif oid == 0x1C4A665F:
+                self.readings.grid.frequency = ensure_type(value, float)
             else:
                 log.warning('_cb_grid: unhandled oid 0x%X', oid)
         except TypeError:

--- a/src/rctmon/models.py
+++ b/src/rctmon/models.py
@@ -137,7 +137,7 @@ class PowerSwitchReadings:
                                    {'inverter': name, 'software_version': str(self.software_version),
                                     'bootloader_version': str(self.bootloader_version)})
 
-        grid_voltage = GaugeMetricFamily('rctmon_grid_voltage', 'Grid voltage by phase', labels=['inverter', 'phase'],
+        grid_voltage = GaugeMetricFamily('rctmon_powerswitch_voltage', 'Grid voltage at powerswitch by phase', labels=['inverter', 'phase'],
                                          unit='volt')
         if self.grid_voltage_l1 is not None:
             grid_voltage.add_metric([name, 'l1'], self.grid_voltage_l1)
@@ -147,7 +147,7 @@ class PowerSwitchReadings:
             grid_voltage.add_metric([name, 'l3'], self.grid_voltage_l3)
         yield grid_voltage
 
-        grid_frequency = GaugeMetricFamily('rctmon_grid_frequency', 'Grid frequency by phase',
+        grid_frequency = GaugeMetricFamily('rctmon_powerswitch_frequency', 'Grid frequency at powerswitch by phase',
                                            labels=['inverter', 'phase'], unit='hertz')
         if self.grid_frequency_l1 is not None:
             grid_frequency.add_metric([name, 'l1'], self.grid_frequency_l1)


### PR DESCRIPTION
This fixes collision of voltage data between grid and powerstorage. Fixes #24. 
When looking into it, the easiest and most consistent way really was to just rename the prefix for the powerswitch metrics to `rctmon_powerswitch`. This decouples it from the collision in `rctmon_grid_voltage` and will not be visible for people not having a powerswitch, because rctmon_grid_frequency would not have been populated (per phase). The only change is for people with powerswitch, reading the frequency per phase, this name has changed to `rctmon_powerswitch_frequency`