### PR TITLE
Remove duplicate handling of battery manager

### DIFF
--- a/src/rctmon/device_manager.py
+++ b/src/rctmon/device_manager.py
@@ -64,7 +64,9 @@ class DeviceManager:
         self.battery_manager = BatteryManager(parent=self)
 
         P_R.register(self)
+        log.info("Registered device manager to prometheus registry")
         P_R.register(self.battery_manager)
+        log.info("Registered battery manager to prometheus registry")
 
     def add_callback(self, oid: int, handler: OidHandler) -> None:
         '''
@@ -106,7 +108,6 @@ class DeviceManager:
         yield inventory
 
         yield from self.readings.collect(self.name)
-        yield from self.battery_manager.collect()
 
     def collect_influx(self, influx: InfluxDB) -> None:
         '''


### PR DESCRIPTION
The battery manager is added on its own to prometheus as a Collection and then called from the collect() function of the device manager. With that, it was collected twice and duplicated metrics.
This is supposed to fix #29.