### PR TITLE
Add basic mqtt support

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -34,6 +34,14 @@ influxdb:
   # Bucket name, InfluxDB 1.8 uses this as database name
   bucket: rct-inverter
 
+mqtt:
+  # Enables writing to MQTT
+  enable: false
+  # Hostname of the MQTT broker to write to
+  mqtt_host: localhost
+  # The interval in which to update MQTT
+  flush_interval_seconds: 30
+
 # Configuration for the logging behaviour of the application. It can be left
 # out entirely for most use-cases, the following shows the internal defaults
 # will be used then. If set, it is handed to "logging.config.dictConfig".

--- a/config.example.yml
+++ b/config.example.yml
@@ -41,6 +41,23 @@ mqtt:
   mqtt_host: localhost
   # The interval in which to update MQTT
   flush_interval_seconds: 30
+  # over write topic prefix
+  # topic_prefix: rctmon/rct01/
+  # user and password to authenticat 
+  auth_user: test
+  auth_pass: "*********"
+  # enable TLS/SSL encryption, most likely `mqtt_port` need to be set
+  tls_enable: false
+  # the mqtt library is very strict in checking TLS certificates.
+  # if you use self-signed certificates, you need to export it and 
+  # give the path here.
+  tls_ca_cert: ./env/ca.pem
+  # Give path to client certificate and key here for authentication. 
+  # tls_certfile: ./env/cert.pem
+  # tls_keyfile: ./env/key.pem
+
+
+
 
 # Configuration for the logging behaviour of the application. It can be left
 # out entirely for most use-cases, the following shows the internal defaults

--- a/docs/use_overview.rst
+++ b/docs/use_overview.rst
@@ -161,7 +161,10 @@ Section "mqtt"
 MQTT is a lightweight publish/subscribe machine-to-machine messaging protocol. All functional metrics exposed for
 prometheus can be published into respective mqtt topics, when MQTT support is enabled by setting ``enable`` to *true*
 and the MQTT server is configured as ``mqtt_host`` and optionally ``mqtt_port`` to use a non-default port.
-There is no support yet for AuthN/AuthZ.
+If MQTT Server use encryption use ``tls_enable: true`` to activate TLS/SSL connection. Use ``tls_insecure`` and 
+``tls_ca_cert`` for fine tuning. For authentication ``mqtt_user`` + ``mqtt_pass`` or/and ``tls_certfile`` + ``tls_keyfile`` 
+can be used. If values should not persis in the MQTT server set ``mqtt_retain: false``. By default the topic prefix is 
+"rctmon", "topic_prefix" will overwrite it. 
 
 Section "logging"
 =================

--- a/docs/use_overview.rst
+++ b/docs/use_overview.rst
@@ -156,6 +156,13 @@ the ``bucket`` field. The ``org`` is only required for version 2.x and ignored i
    As of version ``0.0.1``, the application will hang if the InfluxDB cannot be reached. This will be addresses in
    later releases.
 
+Section "mqtt"
+==============
+MQTT is a lightweight publish/subscribe machine-to-machine messaging protocol. All functional metrics exposed for
+prometheus can be published into respective mqtt topics, when MQTT support is enabled by setting ``enable`` to *true*
+and the MQTT server is configured as ``mqtt_host`` and optionally ``mqtt_port`` to use a non-default port.
+There is no support yet for AuthN/AuthZ.
+
 Section "logging"
 =================
 This section can be omitted entirely, it just shows the internal defaults which log to ``stdout`` by default, suitable

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         'pyyaml',
         'rctclient==0.0.3',
         'requests>=2.21',
+        'paho-mqtt>=1.6'
     ],
     extras_require={
         'dev': [

--- a/src/rctmon/config.py
+++ b/src/rctmon/config.py
@@ -61,10 +61,12 @@ class MqttConfig(BaseModel):
     look for `tls_set` and `tls_insecure_set`
     '''
     enable: bool = False
-    mqtt_host: str = None
+    mqtt_host: str
     mqtt_port: int = 1883
+    mqtt_retain: bool = True
     client_name: str = 'rctmon'
     flush_interval_seconds: int = 30
+    topic_prefix: str = "rctmon"
     auth_user: Union[str, None] = None
     auth_pass: Union[str, None] = None
     tls_enable: bool = False

--- a/src/rctmon/config.py
+++ b/src/rctmon/config.py
@@ -53,6 +53,17 @@ class PrometheusConfig(BaseModel):
     bind_port: int = 9831
 
 
+class MqttConfig(BaseModel):
+    '''
+    Mqtt Configuration.
+    '''
+    enable: bool = False
+    mqtt_host: str = None
+    mqtt_port: int = 1883
+    client_name: str = 'rctmon'
+    flush_interval_seconds: int = 30
+
+
 class RctMonConfig(BaseModel):
     '''
     Main settings container.
@@ -60,3 +71,4 @@ class RctMonConfig(BaseModel):
     device: DeviceConfig
     prometheus: PrometheusConfig
     influxdb: InfluxDBConfig
+    mqtt: MqttConfig

--- a/src/rctmon/config.py
+++ b/src/rctmon/config.py
@@ -8,7 +8,7 @@ Configuration management.
 
 # pylint: disable=too-few-public-methods  # configuration declarations don't contain methods
 
-from typing import Optional
+from typing import Optional, Union
 
 from pydantic import BaseModel, SecretStr
 
@@ -56,13 +56,22 @@ class PrometheusConfig(BaseModel):
 class MqttConfig(BaseModel):
     '''
     Mqtt Configuration.
+    for details about the tls config see:
+    https://eclipse.dev/paho/index.php?page=clients/python/docs/index.php#option-functions
+    look for `tls_set` and `tls_insecure_set`
     '''
     enable: bool = False
     mqtt_host: str = None
     mqtt_port: int = 1883
     client_name: str = 'rctmon'
     flush_interval_seconds: int = 30
-
+    auth_user: Union[str, None] = None
+    auth_pass: Union[str, None] = None
+    tls_enable: bool = False
+    tls_insecure: bool = False
+    tls_ca_cert: Union[str, None] = None
+    tls_certfile: Union[str, None] = None
+    tls_keyfile: Union[str, None] = None
 
 class RctMonConfig(BaseModel):
     '''

--- a/src/rctmon/mqtt.py
+++ b/src/rctmon/mqtt.py
@@ -8,22 +8,32 @@ from .config import MqttConfig
 from prometheus_client.core import REGISTRY, Sample, Metric
 import logging
 
+log = logging.getLogger(__name__)
+
 
 class MqttClient():
+
+    is_connected: bool
+    conf: MqttConfig
+    topic_prefix: str
+    mqtt_client: mqtt.Client
 
     def __init__(self, mqtt_config: MqttConfig):
         self.conf = mqtt_config
         self.is_connected = False
         self.topic_prefix = [self.conf.topic_prefix.strip("/")]
-        self.mqtt_client = self._connect()
+        self.mqtt_client = self._setup_client()
+        self._connect()
 
-    def _connect(self) -> 'mqtt.Client':
+    def _setup_client(self) -> mqtt.Client:
         mqtt_client = mqtt.Client(client_id=self.conf.client_name)
         mqtt_client.enable_logger()
-        self.on_connect = self.__cb_on_connect
+        mqtt_client.on_connect = self.__cb_on_connect
+        mqtt_client.on_disconnect = self.__cb_on_disconnect
 
         if self.conf.auth_user and self.conf.auth_pass:
-            mqtt_client.username_pw_set(self.conf.auth_user, self.conf.auth_pass)
+            mqtt_client.username_pw_set(
+                self.conf.auth_user, self.conf.auth_pass)
         if self.conf.tls_enable:
             mqtt_client.tls_set(
                 self.conf.tls_ca_cert,
@@ -31,17 +41,44 @@ class MqttClient():
                 self.conf.tls_keyfile
             )
             mqtt_client.tls_insecure_set(self.conf.tls_insecure)
-        mqtt_client.connect(self.conf.mqtt_host, self.conf.mqtt_port)
-        # while self.is_connected == False:
-        #     sleep(1)
+
+        mqtt_client.loop_start()
+
         return mqtt_client
 
+    def _connect(self):
+        log.info("MQTT reconnecting")
+        if self.is_connected:
+            log.warn("MQTT already connected, skipping reconnect")
+        else:
+            self.mqtt_client.connect(self.conf.mqtt_host, self.conf.mqtt_port)
+
     def __cb_on_connect(self, mqttc, obj, flags, rc):
-        self.is_connected =  True
+        log.debug("Received onConnect callback")
+        if rc == 0:
+            log.info("MQTT connection established")
+            self.is_connected = True
+        else:
+            log.warning("Couldn't connect to mqtt because of rc %d", rc)
+
+    def __cb_on_disconnect(self, mqttc, obj, rc):
+        log.debug("Received onDisconnect callback")
+        self.is_connected = False
+
+    def publish(self, topic, payload):
+        if self.is_connected:
+            self.mqtt_client.publish(
+                topic=topic, payload=payload, retain=self.conf.mqtt_retain)
+        else:
+            log.warn("MQTT not connected, skipping publishing")
 
     def flush(self):
         """Flush all metrics from the registry to the mqtt server."""
         ignored_labels = ('inverter')  # ignore the generic inverter label
+
+        log.debug("Flushing metrics")
+        if not self.is_connected:
+            self._connect()
 
         metric: Metric = None
         sample: Sample = None
@@ -51,8 +88,8 @@ class MqttClient():
                 # ignore all additional non-functional metrics
                 continue
 
-
-            base_topic = "/".join(self.topic_prefix + (metric.name.split("_")[1:]))
+            base_topic = "/".join(self.topic_prefix +
+                                  (metric.name.split("_")[1:]))
             for sample in metric.samples:
                 topic = base_topic
                 for label in sample.labels.keys():
@@ -62,5 +99,4 @@ class MqttClient():
                         segment = "{}_{}".format(label, sample.labels[label])
                         topic += "/" + segment
 
-                self.mqtt_client.publish(
-                    topic=topic, payload=sample.value, retain=self.conf.mqtt_retain)
+                self.publish(topic=topic, payload=sample.value)

--- a/src/rctmon/mqtt.py
+++ b/src/rctmon/mqtt.py
@@ -1,0 +1,51 @@
+'''
+MQTT integration
+'''
+
+import paho.mqtt.client as mqtt
+from .config import MqttConfig
+from prometheus_client.core import REGISTRY, Sample, Metric
+import logging
+
+
+class MqttClient():
+
+    mqtt_host = None
+    mqtt_port = None
+
+    mqtt_client = None
+
+    def __init__(self, mqtt_config: MqttConfig):
+        self.mqtt_host = mqtt_config.mqtt_host
+        self.mqtt_port = mqtt_config.mqtt_port
+
+        self._connect()
+
+    def _connect(self):
+        self.mqtt_client = mqtt.Client()
+        self.mqtt_client.connect(self.mqtt_host, self.mqtt_port)
+
+    def flush(self):
+        """Flush all metrics from the registry to the mqtt server."""
+        ignored_labels = ('inverter')  # ignore the generic inverter label
+
+        metric: Metric = None
+        sample: Sample = None
+
+        for metric in REGISTRY.collect():
+            if not metric.name.startswith("rctmon"):
+                # ignore all additional non-functional metrics
+                continue
+
+            base_topic = metric.name.replace("_", "/")
+            for sample in metric.samples:
+                topic = base_topic
+                for label in sample.labels.keys():
+                    if label in ignored_labels:
+                        continue
+                    else:
+                        segment = "{}_{}".format(label, sample.labels[label])
+                        topic += "/" + segment
+
+                self.mqtt_client.publish(
+                    topic=topic, payload=sample.value, retain=True)


### PR DESCRIPTION
This adds basic MQTT support. 

When I started playing around with HomeAssistant I tried to find an easy way to integrate the data from the RCT inverter. Having this data already in prometheus, one option was to read it from prometheus - but this is not an ideal integration with HomeAssistant. Another option was an additional bridge between RCT and MQTT, using the rctclient directly. But each individual client against the inverter produces more interfering traffic, so the natural thing seemed to be to just let rctmon emit data to an additional backend. For the sake of simplicity, the MQTT topic names are just derived from the promtheus metric names. This does not always end in ideal or intuitive names, but it works well enough. 