### PR TITLE
Add basic mqtt support (alternative implementation)

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -34,6 +34,14 @@ influxdb:
   # Bucket name, InfluxDB 1.8 uses this as database name
   bucket: rct-inverter
 
+mqtt:
+  # Enables writing to MQTT
+  enable: false
+  # Hostname of the MQTT broker to write to
+  mqtt_host: localhost
+  # The interval in which to update MQTT
+  flush_interval_seconds: 30
+
 # Configuration for the logging behaviour of the application. It can be left
 # out entirely for most use-cases, the following shows the internal defaults
 # will be used then. If set, it is handed to "logging.config.dictConfig".

--- a/config.example.yml
+++ b/config.example.yml
@@ -41,6 +41,23 @@ mqtt:
   mqtt_host: localhost
   # The interval in which to update MQTT
   flush_interval_seconds: 30
+  # over write topic prefix
+  # topic_prefix: rctmon/rct01/
+  # user and password to authenticat 
+  auth_user: test
+  auth_pass: "*********"
+  # enable TLS/SSL encryption, most likely `mqtt_port` need to be set
+  tls_enable: false
+  # the mqtt library is very strict in checking TLS certificates.
+  # if you use self-signed certificates, you need to export it and 
+  # give the path here.
+  tls_ca_cert: ./env/ca.pem
+  # Give path to client certificate and key here for authentication. 
+  # tls_certfile: ./env/cert.pem
+  # tls_keyfile: ./env/key.pem
+
+
+
 
 # Configuration for the logging behaviour of the application. It can be left
 # out entirely for most use-cases, the following shows the internal defaults

--- a/config.example.yml
+++ b/config.example.yml
@@ -39,20 +39,21 @@ mqtt:
   enable: false
   # Hostname of the MQTT broker to write to
   mqtt_host: localhost
-  # The interval in which to update MQTT
-  flush_interval_seconds: 30
-  # over write topic prefix
-  # topic_prefix: rctmon/rct01/
-  # user and password to authenticat 
+  # Port of the MQTT server to use
+  # mqtt_port: 1883
+  # Overwrite topic prefix
+  # topic_prefix: rctmon/rct01
+  # user and password to authenticate
   auth_user: test
   auth_pass: "*********"
-  # enable TLS/SSL encryption, most likely `mqtt_port` need to be set
+  # enable TLS/SSL encryption, most likely `mqtt_port` needs to be set, too
   tls_enable: false
+  #tls_insecure: false
   # the mqtt library is very strict in checking TLS certificates.
-  # if you use self-signed certificates, you need to export it and 
+  # if you use self-signed certificates, you need to export it and
   # give the path here.
   tls_ca_cert: ./env/ca.pem
-  # Give path to client certificate and key here for authentication. 
+  # Give path to client certificate and key here for authentication.
   # tls_certfile: ./env/cert.pem
   # tls_keyfile: ./env/key.pem
 

--- a/docs/use_overview.rst
+++ b/docs/use_overview.rst
@@ -161,7 +161,10 @@ Section "mqtt"
 MQTT is a lightweight publish/subscribe machine-to-machine messaging protocol. All functional metrics exposed for
 prometheus can be published into respective mqtt topics, when MQTT support is enabled by setting ``enable`` to *true*
 and the MQTT server is configured as ``mqtt_host`` and optionally ``mqtt_port`` to use a non-default port.
-There is no support yet for AuthN/AuthZ.
+If MQTT Server use encryption use ``tls_enable: true`` to activate TLS/SSL connection. Use ``tls_insecure`` and 
+``tls_ca_cert`` for fine tuning. For authentication ``mqtt_user`` + ``mqtt_pass`` or/and ``tls_certfile`` + ``tls_keyfile`` 
+can be used. If values should not persis in the MQTT server set ``mqtt_retain: false``. By default the topic prefix is 
+"rctmon", "topic_prefix" will overwrite it. 
 
 Section "logging"
 =================

--- a/docs/use_overview.rst
+++ b/docs/use_overview.rst
@@ -156,6 +156,13 @@ the ``bucket`` field. The ``org`` is only required for version 2.x and ignored i
    As of version ``0.0.1``, the application will hang if the InfluxDB cannot be reached. This will be addresses in
    later releases.
 
+Section "mqtt"
+==============
+MQTT is a lightweight publish/subscribe machine-to-machine messaging protocol. All functional metrics exposed for
+prometheus can be published into respective mqtt topics, when MQTT support is enabled by setting ``enable`` to *true*
+and the MQTT server is configured as ``mqtt_host`` and optionally ``mqtt_port`` to use a non-default port.
+There is no support yet for AuthN/AuthZ.
+
 Section "logging"
 =================
 This section can be omitted entirely, it just shows the internal defaults which log to ``stdout`` by default, suitable

--- a/docs/use_overview.rst
+++ b/docs/use_overview.rst
@@ -159,12 +159,12 @@ the ``bucket`` field. The ``org`` is only required for version 2.x and ignored i
 Section "mqtt"
 ==============
 MQTT is a lightweight publish/subscribe machine-to-machine messaging protocol. All functional metrics exposed for
-prometheus can be published into respective mqtt topics, when MQTT support is enabled by setting ``enable`` to *true*
+prometheus can be published into respective MQTT topics, when MQTT support is enabled by setting ``enable`` to *true*
 and the MQTT server is configured as ``mqtt_host`` and optionally ``mqtt_port`` to use a non-default port.
-If MQTT Server use encryption use ``tls_enable: true`` to activate TLS/SSL connection. Use ``tls_insecure`` and 
-``tls_ca_cert`` for fine tuning. For authentication ``mqtt_user`` + ``mqtt_pass`` or/and ``tls_certfile`` + ``tls_keyfile`` 
-can be used. If values should not persis in the MQTT server set ``mqtt_retain: false``. By default the topic prefix is 
-"rctmon", "topic_prefix" will overwrite it. 
+If the MQTT Server uses encryption, use ``tls_enable: true`` to activate TLS. Use ``tls_insecure`` and
+``tls_ca_cert`` for fine tuning. For authentication ``mqtt_user`` + ``mqtt_pass`` or/and ``tls_certfile`` + ``tls_keyfile``
+can be used. If values should not persist in the MQTT server, set ``mqtt_retain: false``. By default the topic prefix is
+"rctmon", "topic_prefix" will overwrite it.
 
 Section "logging"
 =================

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         'pyyaml',
         'rctclient==0.0.3',
         'requests>=2.21',
+        'paho-mqtt>=1.6'
     ],
     extras_require={
         'dev': [

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         'pyyaml',
         'rctclient==0.0.3',
         'requests>=2.21',
-        'paho-mqtt>=1.6'
+        'paho-mqtt>=2.0',
     ],
     extras_require={
         'dev': [

--- a/src/rctmon/config.py
+++ b/src/rctmon/config.py
@@ -61,10 +61,12 @@ class MqttConfig(BaseModel):
     look for `tls_set` and `tls_insecure_set`
     '''
     enable: bool = False
-    mqtt_host: str = None
+    mqtt_host: str
     mqtt_port: int = 1883
+    mqtt_retain: bool = True
     client_name: str = 'rctmon'
     flush_interval_seconds: int = 30
+    topic_prefix: str = "rctmon"
     auth_user: Union[str, None] = None
     auth_pass: Union[str, None] = None
     tls_enable: bool = False

--- a/src/rctmon/config.py
+++ b/src/rctmon/config.py
@@ -53,6 +53,17 @@ class PrometheusConfig(BaseModel):
     bind_port: int = 9831
 
 
+class MqttConfig(BaseModel):
+    '''
+    Mqtt Configuration.
+    '''
+    enable: bool = False
+    mqtt_host: str = None
+    mqtt_port: int = 1883
+    client_name: str = 'rctmon'
+    flush_interval_seconds: int = 30
+
+
 class RctMonConfig(BaseModel):
     '''
     Main settings container.
@@ -60,3 +71,4 @@ class RctMonConfig(BaseModel):
     device: DeviceConfig
     prometheus: PrometheusConfig
     influxdb: InfluxDBConfig
+    mqtt: MqttConfig

--- a/src/rctmon/config.py
+++ b/src/rctmon/config.py
@@ -8,7 +8,7 @@ Configuration management.
 
 # pylint: disable=too-few-public-methods  # configuration declarations don't contain methods
 
-from typing import Optional
+from typing import Optional, Union
 
 from pydantic import BaseModel, SecretStr
 
@@ -56,13 +56,22 @@ class PrometheusConfig(BaseModel):
 class MqttConfig(BaseModel):
     '''
     Mqtt Configuration.
+    for details about the tls config see:
+    https://eclipse.dev/paho/index.php?page=clients/python/docs/index.php#option-functions
+    look for `tls_set` and `tls_insecure_set`
     '''
     enable: bool = False
     mqtt_host: str = None
     mqtt_port: int = 1883
     client_name: str = 'rctmon'
     flush_interval_seconds: int = 30
-
+    auth_user: Union[str, None] = None
+    auth_pass: Union[str, None] = None
+    tls_enable: bool = False
+    tls_insecure: bool = False
+    tls_ca_cert: Union[str, None] = None
+    tls_certfile: Union[str, None] = None
+    tls_keyfile: Union[str, None] = None
 
 class RctMonConfig(BaseModel):
     '''

--- a/src/rctmon/config.py
+++ b/src/rctmon/config.py
@@ -8,7 +8,7 @@ Configuration management.
 
 # pylint: disable=too-few-public-methods  # configuration declarations don't contain methods
 
-from typing import Optional, Union
+from typing import Optional
 
 from pydantic import BaseModel, SecretStr
 
@@ -65,15 +65,14 @@ class MqttConfig(BaseModel):
     mqtt_port: int = 1883
     mqtt_retain: bool = True
     client_name: str = 'rctmon'
-    flush_interval_seconds: int = 30
     topic_prefix: str = "rctmon"
-    auth_user: Union[str, None] = None
-    auth_pass: Union[str, None] = None
+    auth_user: Optional[str] = None
+    auth_pass: Optional[str] = None
     tls_enable: bool = False
     tls_insecure: bool = False
-    tls_ca_cert: Union[str, None] = None
-    tls_certfile: Union[str, None] = None
-    tls_keyfile: Union[str, None] = None
+    tls_ca_cert: Optional[str] = None
+    tls_certfile: Optional[str] = None
+    tls_keyfile: Optional[str] = None
 
 class RctMonConfig(BaseModel):
     '''

--- a/src/rctmon/event_processor.py
+++ b/src/rctmon/event_processor.py
@@ -1,0 +1,25 @@
+from dataclasses import dataclass
+from typing import Union
+
+@dataclass
+class Event:
+    key: tuple
+    payload: Union[float, int, str]
+
+class EventConsumer:
+
+    def receive_event(self, event: Event):
+        pass
+
+class EventBroadcaster():
+
+    consumers = set[EventConsumer]()
+
+    @classmethod
+    def register_consumer(cls, consumer: EventConsumer):
+        cls.consumers.add(consumer)
+
+    @classmethod
+    def submit_event(cls, event: Event):
+        for consumer in cls.consumers:
+            consumer.receive_event(event)

--- a/src/rctmon/mqtt.py
+++ b/src/rctmon/mqtt.py
@@ -1,0 +1,51 @@
+'''
+MQTT integration
+'''
+
+import paho.mqtt.client as mqtt
+from .config import MqttConfig
+from prometheus_client.core import REGISTRY, Sample, Metric
+import logging
+
+
+class MqttClient():
+
+    mqtt_host = None
+    mqtt_port = None
+
+    mqtt_client = None
+
+    def __init__(self, mqtt_config: MqttConfig):
+        self.mqtt_host = mqtt_config.mqtt_host
+        self.mqtt_port = mqtt_config.mqtt_port
+
+        self._connect()
+
+    def _connect(self):
+        self.mqtt_client = mqtt.Client()
+        self.mqtt_client.connect(self.mqtt_host, self.mqtt_port)
+
+    def flush(self):
+        """Flush all metrics from the registry to the mqtt server."""
+        ignored_labels = ('inverter')  # ignore the generic inverter label
+
+        metric: Metric = None
+        sample: Sample = None
+
+        for metric in REGISTRY.collect():
+            if not metric.name.startswith("rctmon"):
+                # ignore all additional non-functional metrics
+                continue
+
+            base_topic = metric.name.replace("_", "/")
+            for sample in metric.samples:
+                topic = base_topic
+                for label in sample.labels.keys():
+                    if label in ignored_labels:
+                        continue
+                    else:
+                        segment = "{}_{}".format(label, sample.labels[label])
+                        topic += "/" + segment
+
+                self.mqtt_client.publish(
+                    topic=topic, payload=sample.value, retain=True)


### PR DESCRIPTION
This adds basic MQTT supoprt to rctmon, pushing all values to a configurable MQTT server and topic prefix. 

This is an alternative implementation to #32, ith an alternative integration into the existing code base. 
This pull request adds an event broadcast mechanism with a dynamic mechanism to register event listeners. This could even be extended to further decouple the prometheus integration. 
Each change to the model is wrapped into an event and propagated to all registered listeners. The MQTT event listener will derive the topic to publish to and payload from the event. 

In contrast to the initial implementation, this only published data upon changes and is less deeply coupled with the prometheus model, but only tight to the data model. And it can be easily extended to add further event consumers. 

@svalouch Please let me hear what you think. 