### PR TITLE
Expose battery.status and battery.status2 as bitvector equal to battery.status

### DIFF
--- a/src/rctmon/battery_manager.py
+++ b/src/rctmon/battery_manager.py
@@ -100,6 +100,14 @@ class BatteryManager:
             battery_bat_status = GaugeMetricFamily('rctmon_battery_bat_status', 'Battery status', labels=['inverter'])
             battery_bat_status.add_metric([self.parent.name], self.readings.bat_status)
             yield battery_bat_status
+        if self.readings.status is not None:
+            battery_status = GaugeMetricFamily('rctmon_battery_status', 'Battery status', labels=['inverter'])
+            battery_status.add_metric([self.parent.name], self.readings.status)
+            yield battery_status
+        if self.readings.status2 is not None:
+            battery_status2 = GaugeMetricFamily('rctmon_battery_status2', 'Battery status 2', labels=['inverter'])
+            battery_status2.add_metric([self.parent.name], self.readings.status2)
+            yield battery_status2
         if self.readings.impedance_fine is not None:
             battery_impedance_fine = GaugeMetricFamily('rctmon_battery_impedance_fine', 'Battery impedance (fine)',
                                                        labels=['inverter'])


### PR DESCRIPTION
This will expose battery.status and battery.status2 as native bitvector equally to battery.bat_status to check their use in real-life. 

Ideally, we'd already decode the bitvector for prometheus and emit a marker label per bit, but this is not done for the battery.bat_status and still is worthwile. 

This MR was triggered via https://github.com/svalouch/python-rctclient/issues/39, suggesting status2 could expose more informations. 