### PR TITLE
Add prometheus support for cell voltages and temperatures and historic min/max voltages/temperatures

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         'prometheus_client>=0.9.0',
         'pydantic>=1.2',
         'pyyaml',
-        'rctclient==0.0.3',
+        'rctclient==0.0.5',
         'requests>=2.21',
         'paho-mqtt>=2.0',
     ],

--- a/src/rctmon/battery_manager.py
+++ b/src/rctmon/battery_manager.py
@@ -14,7 +14,7 @@ from typing import Any, Dict, Generator, Optional
 from influxdb_client import Point, WritePrecision as InfluxWritePrecision
 from prometheus_client.core import InfoMetricFamily, CounterMetricFamily, GaugeMetricFamily
 from rctclient.registry import REGISTRY as R
-from rctclient.types import BatteryModuleStatus
+from rctclient.types import BatteryModuleStatus, BatteryModuleStatistics
 
 from .influx import InfluxDB
 from .models import BatteryInfo, BatteryReadings
@@ -30,7 +30,8 @@ BAT_IDS_CYCLES = {0xA6C4FD4A: 0, 0xCFA8BC4: 1, 0x5BA122A5: 2, 0x89B25F4B: 3, 0x5
                   0x27C39CEA: 6}
 BAT_IDS_CELLS = {0xF8C0D255: 0, 0x8EF6FBBD: 1, 0x69B8FF28: 2, 0xC8609C8E: 3, 0x1348AB07: 4, 0x62D645D9: 5,
                  0x40FF01B7: 6}
-
+BAT_IDS_STATS = {0x34A164E7: 0, 0xFB796780: 1, 0x74FD4609: 2, 0x1676FA6: 3, 0xDACF21B: 4, 0x23E55DA0: 5,
+                 0xF99E8CC8: 6}
 
 class BatteryManager:
     '''
@@ -133,6 +134,18 @@ class BatteryManager:
             cell_voltages = GaugeMetricFamily(name='rctmon_battery_module_cell_voltage',
                                               documentation='Individual cell voltage in battery modules',
                                               labels=['inverter', 'module', 'cell'], unit='volt')
+            min_voltage = GaugeMetricFamily(name='rctmon_battery_module_voltage_min',
+                                              documentation='Historic minimum voltage in battery module',
+                                              labels=['inverter', 'module'], unit='volt')
+            max_voltage = GaugeMetricFamily(name='rctmon_battery_module_voltage_max',
+                                              documentation='Historic maximum voltage in battery module',
+                                              labels=['inverter', 'module'], unit='volt')
+            min_temperature = GaugeMetricFamily(name='rctmon_battery_module_temperature_min',
+                                              documentation='Historic minimum temperature in battery module',
+                                              labels=['inverter', 'module'], unit='celsius')
+            max_temperature = GaugeMetricFamily(name='rctmon_battery_module_temperature_max',
+                                              documentation='Historic maximum temperature in battery module',
+                                              labels=['inverter', 'module'], unit='celsius')
             for battery in self.batteries.values():
                 if battery:
                     yield InfoMetricFamily('rctmon_battery_module', 'Information about individual battery modules',
@@ -141,12 +154,24 @@ class BatteryManager:
 
                     if battery.cycle_count is not None:
                         cycles.add_metric([self.parent.name, str(battery.num)], battery.cycle_count)
+                    if battery.min_voltage is not None:
+                        min_voltage.add_metric([self.parent.name, str(battery.num)], battery.min_voltage)
+                    if battery.max_voltage is not None:
+                        max_voltage.add_metric([self.parent.name, str(battery.num)], battery.max_voltage)
+                    if battery.min_temperature is not None:
+                        min_temperature.add_metric([self.parent.name, str(battery.num)], battery.min_temperature)
+                    if battery.max_temperature is not None:
+                        max_temperature.add_metric([self.parent.name, str(battery.num)], battery.max_temperature)
                     if len(battery.cells)>0:
                         for cell_id, cell in battery.cells.items():
                             cell_temperatures.add_metric([self.parent.name, str(battery.num), str(cell_id)], cell.temperature)
                             cell_voltages.add_metric([self.parent.name, str(battery.num), str(cell_id)], cell.voltage)
             yield cell_temperatures
             yield cell_voltages
+            yield min_voltage
+            yield max_voltage
+            yield min_temperature
+            yield max_temperature
             yield cycles
 
     def collect_influx(self, influx: InfluxDB) -> None:
@@ -202,6 +227,7 @@ class BatteryManager:
             influx.add_points(modules.values())
 
             # TODO: cell temperatures and voltages
+            # TODO: historic min/max temperatures/voltages
 
     def cb_battery_type(self, oid: int, value: Any) -> None:
         '''
@@ -270,6 +296,8 @@ class BatteryManager:
                 self.parent.add_ids([f'battery.stack_cycles[{bat_id}]'], interval=300, handler=self._cb_battery_cycles)
                 # request temperatures/voltages per cell
                 self.parent.add_ids([f'battery.cells[{bat_id}]'], interval=300, handler=self._cb_battery_cells)
+                # request historic min/max temperatures/voltages
+                self.parent.add_ids([f'battery.cells_stat[{bat_id}]'], interval=300, handler=self._cb_battery_cells_stats)
 
     def _cb_battery_cycles(self, oid: int, value: Any) -> None:
         '''
@@ -300,6 +328,26 @@ class BatteryManager:
                 self.batteries[bat_id].populate_cells_from_status(value)
             except KeyError:
                 log.warning('BatteryManager: Attempt to set cell data for unknown battery #%d', bat_id)
+            except TypeError as e:
+                log.warning('Got wrong type %s for %s', type(value), R.get_by_id(oid).name)
+                log.warning(str(e))
+
+    def _cb_battery_cells_stats(self, oid: int, value: BatteryModuleStatistics) -> None:
+        '''
+        Handler for ``battery.cells_stat[X]``.
+        '''
+        try:
+            bat_id = BAT_IDS_STATS[oid]
+        except KeyError:
+            log.error('battery.cells_stat: Got unknown OID 0x%X', oid)
+        else:
+            try:
+                self.batteries[bat_id].min_voltage = ensure_type(value.u_min.value, float)
+                self.batteries[bat_id].max_voltage = ensure_type(value.u_max.value, float)
+                self.batteries[bat_id].min_temperature = ensure_type(value.t_min.value, float)
+                self.batteries[bat_id].max_temperature = ensure_type(value.t_max.value, float)
+            except KeyError:
+                log.warning('BatteryManager: Attempt to set statistics data for unknown battery #%d', bat_id)
             except TypeError as e:
                 log.warning('Got wrong type %s for %s', type(value), R.get_by_id(oid).name)
                 log.warning(str(e))

--- a/src/rctmon/battery_manager.py
+++ b/src/rctmon/battery_manager.py
@@ -14,6 +14,7 @@ from typing import Any, Dict, Generator, Optional
 from influxdb_client import Point, WritePrecision as InfluxWritePrecision
 from prometheus_client.core import InfoMetricFamily, CounterMetricFamily, GaugeMetricFamily
 from rctclient.registry import REGISTRY as R
+from rctclient.types import BatteryModuleStatus
 
 from .influx import InfluxDB
 from .models import BatteryInfo, BatteryReadings
@@ -27,6 +28,8 @@ BAT_IDS_MODULE_SN = {0xFBF6D834: 0, 0x99396810: 1, 0x73489528: 2, 0x257B7612: 3,
                      0x5939EC5D: 6}
 BAT_IDS_CYCLES = {0xA6C4FD4A: 0, 0xCFA8BC4: 1, 0x5BA122A5: 2, 0x89B25F4B: 3, 0x5A9EEFF0: 4, 0x2A30A97E: 5,
                   0x27C39CEA: 6}
+BAT_IDS_CELLS = {0xF8C0D255: 0, 0x8EF6FBBD: 1, 0x69B8FF28: 2, 0xC8609C8E: 3, 0x1348AB07: 4, 0x62D645D9: 5,
+                 0x40FF01B7: 6}
 
 
 class BatteryManager:
@@ -37,7 +40,6 @@ class BatteryManager:
     have_battery: Optional[bool] = None
 
     # Number of battery modules, None if not yet known
-    num_batteries: Optional[int] = None
     batteries: Dict[int, BatteryInfo]
 
     readings: BatteryReadings
@@ -121,9 +123,16 @@ class BatteryManager:
             battery_used_energy.add_metric([self.parent.name], self.readings.used_energy)
             yield battery_used_energy
 
-        if self.num_batteries and self.num_batteries > 0:
-            cycles = CounterMetricFamily('rctmon_battery_module_cycles', 'Number of cycles the battery has accumulated'
-                                         ' over its lifetime', labels=['inverter', 'module'])
+        if len(self.batteries) > 0:
+            cycles = CounterMetricFamily(name='rctmon_battery_module_cycles',
+                                         documentation='Number of cycles the battery has accumulated over its lifetime',
+                                         labels=['inverter', 'module'])
+            cell_temperatures = GaugeMetricFamily(name='rctmon_battery_module_cell_temperature',
+                                                  documentation='Individual cell temperature in battery modules',
+                                                  labels=['inverter', 'module', 'cell'], unit='celsius')
+            cell_voltages = GaugeMetricFamily(name='rctmon_battery_module_cell_voltage',
+                                              documentation='Individual cell voltage in battery modules',
+                                              labels=['inverter', 'module', 'cell'], unit='volt')
             for battery in self.batteries.values():
                 if battery:
                     yield InfoMetricFamily('rctmon_battery_module', 'Information about individual battery modules',
@@ -132,6 +141,12 @@ class BatteryManager:
 
                     if battery.cycle_count is not None:
                         cycles.add_metric([self.parent.name, str(battery.num)], battery.cycle_count)
+                    if len(battery.cells)>0:
+                        for cell_id, cell in battery.cells.items():
+                            cell_temperatures.add_metric([self.parent.name, str(battery.num), str(cell_id)], cell.temperature)
+                            cell_voltages.add_metric([self.parent.name, str(battery.num), str(cell_id)], cell.voltage)
+            yield cell_temperatures
+            yield cell_voltages
             yield cycles
 
     def collect_influx(self, influx: InfluxDB) -> None:
@@ -185,6 +200,8 @@ class BatteryManager:
                         modules[battery.num] = modules[battery.num].field('cycles', battery.cycle_count)
 
             influx.add_points(modules.values())
+
+            # TODO: cell temperatures and voltages
 
     def cb_battery_type(self, oid: int, value: Any) -> None:
         '''
@@ -251,6 +268,8 @@ class BatteryManager:
                 self.batteries[bat_id] = BatteryInfo(bat_id, value)
                 # request the modules cycle count from now on
                 self.parent.add_ids([f'battery.stack_cycles[{bat_id}]'], interval=300, handler=self._cb_battery_cycles)
+                # request temperatures/voltages per cell
+                self.parent.add_ids([f'battery.cells[{bat_id}]'], interval=300, handler=self._cb_battery_cells)
 
     def _cb_battery_cycles(self, oid: int, value: Any) -> None:
         '''
@@ -267,6 +286,23 @@ class BatteryManager:
                 log.warning('BatteryManager: Attempt to set cycle count for unknown battery #%d', bat_id)
             except TypeError:
                 log.warning('Got wrong type %s for %s', type(value), R.get_by_id(oid).name)
+
+    def _cb_battery_cells(self, oid: int, value: BatteryModuleStatus) -> None:
+        '''
+        Handler for ``battery.cells[X]``.
+        '''
+        try:
+            bat_id = BAT_IDS_CELLS[oid]
+        except KeyError:
+            log.error('battery.cells: Got unknown OID 0x%X', oid)
+        else:
+            try:
+                self.batteries[bat_id].populate_cells_from_status(value)
+            except KeyError:
+                log.warning('BatteryManager: Attempt to set cell data for unknown battery #%d', bat_id)
+            except TypeError as e:
+                log.warning('Got wrong type %s for %s', type(value), R.get_by_id(oid).name)
+                log.warning(str(e))
 
     def _cb_readings(self, oid: int, value: Any) -> None:
         try:

--- a/src/rctmon/models.py
+++ b/src/rctmon/models.py
@@ -42,6 +42,10 @@ class BatteryInfo:
     serial: str
     cycle_count: Optional[int] = None
     cells: dict[int, CellInfo] = {}
+    min_voltage: Optional[float] = None
+    max_voltage: Optional[float] = None
+    min_temperature: Optional[float] = None
+    max_temperature: Optional[float] = None
 
     def __init__(self, num: int, serial: str) -> None:
         self.num = num

--- a/src/rctmon/models.py
+++ b/src/rctmon/models.py
@@ -12,9 +12,25 @@ from dataclasses import dataclass
 from typing import Generator, Optional
 
 from prometheus_client.core import GaugeMetricFamily, InfoMetricFamily
+from rctclient.types import BatteryModuleStatus
+
 from .event_processor import EventBroadcaster, Event
 
 log = logging.getLogger(__name__)
+
+class CellInfo:
+    '''
+    Information about a single cell in a battery.
+    '''
+    voltage: float
+    temperature: float
+
+    def __init__(self, voltage: float, temperature: float) -> None:
+        self.voltage = voltage
+        self.temperature = temperature
+
+    def __repr__(self) -> str:
+        return f'<CellInfo("{self.voltage}V", "{self.temperature}°C")>'
 
 
 class BatteryInfo:
@@ -25,10 +41,12 @@ class BatteryInfo:
     num: int
     serial: str
     cycle_count: Optional[int] = None
+    cells: dict[int, CellInfo] = {}
 
     def __init__(self, num: int, serial: str) -> None:
         self.num = num
         self.serial = serial
+        self.cells = {}
 
     def __repr__(self) -> str:
         return f'<BatteryInfo({self.num}, "{self.serial}")>'
@@ -38,6 +56,13 @@ class BatteryInfo:
         Returns whether the information is complete.
         '''
         return self.cycle_count is not None
+
+    def populate_cells_from_status(self, status: BatteryModuleStatus) -> None:
+        '''
+        Populates ``cells`` from a decoded ``BatteryModuleStatus`` payload.
+        '''
+        self.cells = {cell_id: CellInfo(voltage=cell.voltage_v, temperature=int(cell.temperature_c))
+                      for cell_id, cell in status.cells.items()}
 
 class AbstractReadings:
 

--- a/src/rctmon/monitoring.py
+++ b/src/rctmon/monitoring.py
@@ -13,6 +13,8 @@ from prometheus_client import Counter, Gauge, Info, MetricsHandler
 
 from .config import PrometheusConfig
 
+import logging
+
 
 MON_BYTES_RECEIVED = Counter('rctmon_bytes_received', 'Amount of bytes received since the start of the application')
 MON_BYTES_SENT = Counter('rctmon_bytes_sent', 'Amount of bytes sent since the start of the application')
@@ -26,6 +28,8 @@ MON_INFO = Info('rctmon', 'Information about the application')
 
 
 class MainHandler(MetricsHandler):
+    log = logging.getLogger(__name__)
+
     def do_GET(self):
         path = urlparse(self.path).path
         try:
@@ -37,6 +41,7 @@ class MainHandler(MetricsHandler):
             else:
                 self.send_error(404)
         except Exception:  # pylint: disable=broad-except
+            self.log.error('Error handling request', exc_info=True)
             self.send_error(500, 'Internal error')
 
     def send_html_main(self) -> None:


### PR DESCRIPTION
This adds support for cell temperatures and cell voltages, for prometheus only. 
On a battery module level, it as well adds historic data for min/max temperatures/voltages. 

I skipped metrics for which cell and which timestamp caused that min/max value. Generally the data is available, but doesn't make much sense in a time series. 

influxdb is still a TODO, I don't use that and have no experience with that. 